### PR TITLE
Update Readme.adoc fix url

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,6 +7,6 @@ And if it did the standard handler does not include the right library for ssl.
 
 = How To Use
 
-Add `gem 'sslbrick', git: 'git@github.com:ogd-software/SSLbrick.git'` to Gemfile.
+Add `gem 'sslbrick', git: 'https://github.com/ogd-software/SSLbrick.git'` to Gemfile.
 
 Install with `bundle install`.


### PR DESCRIPTION
Fixes gem url. Not everyone has SSH access to github configured
remained from original which was only accessable via SSH