### PR TITLE
Fix punctuation and capitalization in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,12 +1,11 @@
 = SSLbrick
 
-SSL WEBrick handler, modified copy of the standard WEBrick handler with options to force SSL
-Needed because rails s does not parse and pass the option to enable ssl.
-And if it did the standard handler does not include the right library for ssl.
-
+SSL WEBrick handler, modified copy of the standard WEBrick handler with options to force SSL.
+Needed because `rails server` does not parse and pass the option to enable SSL.
+(And if it did, the standard handler does not include the right library for SSL.)
 
 = How To Use
 
-Add `gem 'sslbrick', git: 'https://github.com/ogd-software/SSLbrick.git'` to Gemfile.
+Add `gem 'sslbrick', git: 'https://github.com/ogd-software/SSLbrick.git'` to your Gemfile.
 
 Install with `bundle install`.


### PR DESCRIPTION
Small improvements of the README file. Some punctuation was missing, I've also made capitalization of 'SSL' consistent.