### PR TITLE
Fix hompage url for new rubygems version

### DIFF
--- a/sslbrick.gemspec
+++ b/sslbrick.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{SSL WEBrick handler}
   spec.description   = %q{Modified copy of the standard WEBrick handler with options to force SSL}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/ogd-software/SSLbrick"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
The gemspec at sslbrick.gemspec is not valid. Please fix this gemspec.
The validation error was '"TODO: Put your gem's website or public repo URL
here." is not a valid HTTP URI